### PR TITLE
fix: installation on Debian Bookworm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@ from setuptools import setup
 
 setup(
     name='dchmerge',
-    version='0.1.0',
+    version='0.1.1',
     description='Merge conflict resolver for debian changelogs',
     author='Lukas Cone',
     url='https://github.com/PredatorCZ/debchangelog',
-    scripts=['dchmerge.py', 'deb.py']
+    scripts=['dchmerge.py', 'deb.py'],
+    py_modules=[]
 )


### PR DESCRIPTION
Installation by `python3 setup.py install` is not working on Debian Bookworm with following error:

```
error: Multiple top-level modules discovered in a flat-layout: ['deb', 'dchmerge', 'test_test'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple modules
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
```

Specifying concrete modules in py_modules fixes installation process, or it works also with `py_modules=[]` with auto observation.